### PR TITLE
Use special-use domain name instead of actual services domain

### DIFF
--- a/lib/feiku.rb
+++ b/lib/feiku.rb
@@ -13,4 +13,4 @@ module Feiku
 end
 
 Feiku.register(:Email, format: "%<name>ss@%<domain>s",
-                       value: { name: %w[alice bob charlie], domain: %w[gmail.com yahoo.com] })
+                       value: { name: %w[alice bob charlie], domain: %w[a.example.invalid b.example.invalid] })


### PR DESCRIPTION
## What
These domains are from existing mail services. So generated mail address may work correctly and it causes unexpected behavior.

ref https://datatracker.ietf.org/doc/html/rfc6761